### PR TITLE
Fix ignored model path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ internals.configure = async function(opts) {
 
     let db = null;
     if (opts.models) {
-        const files = await Models.getFiles(opts.models);
+        const files = await Models.getFiles(opts.models, opts.ignoredModels);
         let models = await Models.load(files, opts.sequelize.import.bind(opts.sequelize));
         models = await Models.applyRelations(models);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -10,6 +10,7 @@ internals.option = exports.option = Joi.object().keys({
         .token()
         .required(),
     models: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    ignoredModels: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
     sequelize: Joi.object()
         .type(Sequelize)
         .required(),


### PR DESCRIPTION
⚠️  The model declaration paths does not support ignored path.
It seems it is supported here https://github.com/danecando/hapi-sequelize/blob/master/lib/models.js#L6
But it is not called with ignored param here https://github.com/danecando/hapi-sequelize/blob/master/lib/index.js#L34
When adding 
```
models: ['./server/models/**/*.js']
```
It causes an issue: `TypeError: defineCall is not a function` when we have this`models/index.js` generated by sequelize cli.

Adding `opts.ignoredModels` and call 
```
const files = Models.getFiles(opts.models, opts.ignoredModels);
```
in `lib/index.js` should solve the issue.

