### PR TITLE
Remove unnecessary use of Promise.resolve

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -20,7 +20,7 @@ async function getFiles(paths, ignored) {
 }
 
 async function load(files, fn) {
-    if (!files) return Promise.resolve([]);
+    if (!files) return [];
     if (!Array.isArray(files)) files = [files];
 
     return files.reduce((acc, file) => {


### PR DESCRIPTION
Thanks for fixing the error I left behind. I was a bit too quick it seems and didn't see I let a `resolve` call when none was in scope.
 
However you don't need to return a promise from an async function when you only want to return directly a value because the value you return will be wrapped in a promise.

> When an async function is called, it returns a Promise. When the async function returns a value, the Promise will be resolved with the returned value.  When the async function throws an exception or some value, the Promise will be rejected with the thrown value.

[MDN Source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
