### PR TITLE
Add __dirname before model path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ server.register([
         options: [
             {
                 name: 'dbname', // identifier
-                models: ['./server/models/**/*.js'], // paths/globs to model files
+                models: [__dirname + './server/models/**/*.js'], // paths/globs to model files
                 sequelize: new Sequelize(config, opts), // sequelize instance
                 sync: true, // sync models - default false
                 forceSync: false, // force sync (drops tables) - default false


### PR DESCRIPTION
I got a mysterious error `TypeError: Class constructor Model cannot be invoked without 'new'` and tried to debug for a while until I realized the reason of the error. My models are in files like `'./**/model.js'` so I adapted my case as described in the readme... but actually a file `./node_modules/sequelize/lib/model.js` match this regex unless the above regex is prefixed by `__dirname`. This is why I think it would be great to add the __dirname.