### PR TITLE
Add TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'hapi-sequelizejs';


### PR DESCRIPTION
I wanted to use this package in Hapi/TypeScript project so I had to add this file (basic TypeScript declaration) in `node_modules/hapi-sequelizejs` to work properly.