### PR TITLE
Upgrade support to Sequelize v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Thanks in advance ❤️
 
 ## Compatibility
 
-Compatible with hapi.js version `19.x` and sequelize `5.x`.
+Compatible with hapi.js version `19.x` and sequelize `6.x`.
 
 Check the [releases page](https://github.com/valtlfelipe/hapi-sequelizejs/releases) for the changelog.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ async function configure(options) {
     let db = null;
     if (options.models) {
         const files = await Models.getFiles(options.models, options.ignoredModels);
-        let models = await Models.load(files, options.sequelize.import.bind(options.sequelize));
+        let models = await Models.load(files, options.sequelize);
         models = await Models.applyRelations(models);
 
         if (options.sync) {

--- a/lib/models.js
+++ b/lib/models.js
@@ -28,7 +28,7 @@ async function getFiles(paths, ignored) {
     }, []);
 }
 
-async function load(files, fn) {
+async function load(files, sequelize) {
     if (!files) {
         return [];
     }
@@ -40,7 +40,7 @@ async function load(files, fn) {
     return files.reduce((acc, file) => {
         const models = {};
         const filepath = Path.isAbsolute(file) ? file : Path.join(process.cwd(), file);
-        const Model = fn(filepath);
+        const Model = require(filepath)(sequelize, sequelize.Sequelize.DataTypes);
         models[Model.name] = Model;
         return Object.assign({}, acc, models);
     }, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "hapi-sequelizejs",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -886,12 +886,6 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1058,16 +1052,6 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
             "dev": true
-        },
-        "cls-bluebird": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-            "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-            "dev": true,
-            "requires": {
-                "is-bluebird": "^1.0.2",
-                "shimmer": "^1.1.0"
-            }
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -2261,12 +2245,6 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
-        "is-bluebird": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-            "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
-            "dev": true
-        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2796,15 +2774,15 @@
             }
         },
         "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
             "dev": true
         },
         "moment-timezone": {
-            "version": "0.5.28",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-            "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+            "version": "0.5.31",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+            "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
             "dev": true,
             "requires": {
                 "moment": ">= 2.9.0"
@@ -3488,32 +3466,44 @@
             "dev": true
         },
         "sequelize": {
-            "version": "5.21.5",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.5.tgz",
-            "integrity": "sha512-n9hR5K4uQGmBGK/Y/iqewCeSFmKVsd0TRnh0tfoLoAkmXbKC4tpeK96RhKs7d+TTMtrJlgt2TNLVBaAxEwC4iw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.1.0.tgz",
+            "integrity": "sha512-8x603RQrj14QZ4dGpsYPMr3YGqsihNX9WPclNN83prwrhHAJH9LHfOG/pK2XUdrwYtbRz+2a7xKXK7rVdw3P2A==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.0",
-                "cls-bluebird": "^2.1.0",
                 "debug": "^4.1.1",
                 "dottie": "^2.0.0",
                 "inflection": "1.12.0",
                 "lodash": "^4.17.15",
-                "moment": "^2.24.0",
-                "moment-timezone": "^0.5.21",
+                "moment": "^2.26.0",
+                "moment-timezone": "^0.5.31",
                 "retry-as-promised": "^3.2.0",
-                "semver": "^6.3.0",
-                "sequelize-pool": "^2.3.0",
+                "semver": "^7.3.2",
+                "sequelize-pool": "^6.0.0",
                 "toposort-class": "^1.0.1",
-                "uuid": "^3.3.3",
+                "uuid": "^8.1.0",
                 "validator": "^10.11.0",
-                "wkx": "^0.4.8"
+                "wkx": "^0.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+                    "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+                    "dev": true
+                }
             }
         },
         "sequelize-pool": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-            "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.0.0.tgz",
+            "integrity": "sha512-D/VfOX2Z+6JTWqM73lhcqMXp1X4CeqRNVMlndvbOMtyjFAZ2kYzH7rGFGFrLO1r+RZQdc/h+3zQL4nd3cclNLg==",
             "dev": true
         },
         "set-blocking": {
@@ -3535,12 +3525,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
-        },
-        "shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
             "dev": true
         },
         "signal-exit": {
@@ -4022,9 +4006,9 @@
             "dev": true
         },
         "wkx": {
-            "version": "0.4.8",
-            "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-            "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+            "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
             "dev": true,
             "requires": {
                 "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hapi-sequelizejs",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "hapi.js plugin for the Sequelize ORM",
     "main": "lib/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -50,15 +50,15 @@
     "license": "MIT",
     "devDependencies": {
         "@hapi/code": "^8.0.1",
+        "@hapi/hapi": "^19.1.1",
+        "@hapi/lab": "^22.0.4",
         "coveralls": "^3.1.0",
         "eslint": "^7.1.0",
-        "@hapi/hapi": "^19.1.1",
         "husky": "^4.2.5",
-        "@hapi/lab": "^22.0.4",
         "lint-staged": "^10.2.8",
         "mysql2": "^2.1.0",
         "prettier": "^2.0.5",
-        "sequelize": "^5.21.5",
+        "sequelize": "^6.1.0",
         "sqlite3": "^4.2.0"
     },
     "peerDependencies": {
@@ -70,9 +70,9 @@
         "npm": ">=5.6.0"
     },
     "dependencies": {
-        "glob": "7.1.6",
         "@hapi/hoek": "9.0.4",
-        "@hapi/joi": "17.1.1"
+        "@hapi/joi": "17.1.1",
+        "glob": "7.1.6"
     },
     "funding": {
         "type": "individual",

--- a/test/models/shop/product/category.js
+++ b/test/models/shop/product/category.js
@@ -1,4 +1,4 @@
-// return Category model as a function to sequelize.import()
+// return Category model as a function
 
 module.exports = function (sequelize, DataTypes) {
     const Category = sequelize.define('Category', {

--- a/test/models/shop/product/product.js
+++ b/test/models/shop/product/product.js
@@ -1,4 +1,4 @@
-// return Product model as a function to sequelize.import()
+// return Product model as a function
 
 module.exports = function (sequelize, DataTypes) {
     const Product = sequelize.define('Product', {

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -1,4 +1,4 @@
-// return User model as a function to sequelize.import()
+// return User model as a function
 
 module.exports = function (sequelize, DataTypes) {
     return sequelize.define('User', {


### PR DESCRIPTION
Minor changes needed - as they dropped the support for `sequelize.import()` which was used in `models.load()`.  Now using require() directly and passing `sequelize` and `sequelize.Sequelize.DataTypes` into the model files.

Tests passing against Sequalize versions: 4.x, 5.x, 6.x

This should fix #40 